### PR TITLE
Allow lookup of a user profile by username.

### DIFF
--- a/bucket/appbucket/urls.py
+++ b/bucket/appbucket/urls.py
@@ -8,7 +8,7 @@ urlpatterns = patterns('',
     url(r'^profile/$', 'appbucket.views.my_profile', name='my_profile'),
     url(r'^profile/id/(?P<user_id>\d+)/$', 'appbucket.views.user_profile', name='user_profile'),
     url(r'^profile/edit/$', 'appbucket.views.edit_profile', name='edit_profile'),
-    url(r'^profile/(?P<user_name>[\w.@+-]+)/$', 'appbucket.views.user_profile', name='user_profile_name'),
+    url(r'^profile/(?P<user_name>[a-zA-Z0-9.-]+)/$', 'appbucket.views.user_profile', name='user_profile_name'),
     url(r'^addItem/$', 'appbucket.views.add_item', name='add_item'),
     url(r'^item/edit/(?P<item_id>\d+)/$', 'appbucket.views.edit_item', name='edit_item'),
     

--- a/bucket/appbucket/urls.py
+++ b/bucket/appbucket/urls.py
@@ -7,7 +7,6 @@ urlpatterns = patterns('',
     url(r'^badges/$', 'appbucket.views.badges', name='badges'),
     url(r'^profile/$', 'appbucket.views.my_profile', name='my_profile'),
     url(r'^profile/id/(?P<user_id>\d+)/$', 'appbucket.views.user_profile', name='user_profile'),
-    # Following line makes it impossible to have a user named "edit"
     url(r'^profile/edit/$', 'appbucket.views.edit_profile', name='edit_profile'),
     url(r'^profile/(?P<user_name>[\w.@+-]+)/$', 'appbucket.views.user_profile', name='user_profile_name'),
     url(r'^addItem/$', 'appbucket.views.add_item', name='add_item'),

--- a/bucket/appbucket/urls.py
+++ b/bucket/appbucket/urls.py
@@ -6,8 +6,10 @@ urlpatterns = patterns('',
     url(r'^about/$', 'appbucket.views.about', name='about'),
     url(r'^badges/$', 'appbucket.views.badges', name='badges'),
     url(r'^profile/$', 'appbucket.views.my_profile', name='my_profile'),
-    url(r'^profile/(?P<user_id>\d+)/$', 'appbucket.views.user_profile', name='user_profile'),
+    url(r'^profile/id/(?P<user_id>\d+)/$', 'appbucket.views.user_profile', name='user_profile'),
+    # Following line makes it impossible to have a user named "edit"
     url(r'^profile/edit/$', 'appbucket.views.edit_profile', name='edit_profile'),
+    url(r'^profile/(?P<user_name>[\w.@+-]+)/$', 'appbucket.views.user_profile', name='user_profile_name'),
     url(r'^addItem/$', 'appbucket.views.add_item', name='add_item'),
     url(r'^item/edit/(?P<item_id>\d+)/$', 'appbucket.views.edit_item', name='edit_item'),
     

--- a/bucket/appbucket/views.py
+++ b/bucket/appbucket/views.py
@@ -144,7 +144,7 @@ def get_badges(user):
 
 @login_required
 def my_profile(request):
-    return user_profile(request, user_id=request.user.id)
+    return redirect("app:user_profile_name", user_name=request.user.username)
 
 @login_required
 def edit_profile(request):

--- a/bucket/appbucket/views.py
+++ b/bucket/appbucket/views.py
@@ -39,8 +39,12 @@ def badges(request):
 def index(request):
     return render_to_response("index.html", context_instance=RequestContext(request))
 
-def user_profile(request, user_id=None):
-    profile_user = get_object_or_404(User, id=user_id)
+def user_profile(request, user_id=None, user_name=None):
+    profile_user = None
+    if (user_id is not None):
+        profile_user = get_object_or_404(User, id=user_id)
+    else:
+        profile_user = get_object_or_404(User, username=user_name)
 
     default_image_url = "http://bucketeer.me/static/bucket/default_bucket_person.png"
 

--- a/bucket/bucket/forms.py
+++ b/bucket/bucket/forms.py
@@ -26,6 +26,15 @@ class UserForm(UserCreationForm):
     email = forms.EmailField(label='Email', required=True)
     first_name = forms.CharField(label='First Name', required=True)
     last_name = forms.CharField(label='Last Name', required=True)
+
+    def clean_username(self):
+        reserved_names = ["www", "edit", "id"]
+
+        username = self.cleaned_data["username"]
+        for reserved_name in reserved_names:
+            if (username == reserved_name):
+                raise forms.ValidationError("Invalid user name. Please choose a different name.")
+        return username
     
     class Meta:
         model = User

--- a/bucket/bucket/forms.py
+++ b/bucket/bucket/forms.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 class UserForm(UserCreationForm):
     """
     Allows the creation of a new user, with fields:
-        - username
+        - username (additional validation added)
         - first_name
         - last_name
         - email
@@ -14,6 +14,15 @@ class UserForm(UserCreationForm):
         - password2
     """
     #All fields are required
+    username = forms.RegexField(label="Username", max_length=30,
+        regex=r'^[a-zA-Z0-9.-]+$',
+        help_text = "Required. 30 characters or fewer. Letters, digits, '.' and '-' only.",
+        error_messages = 
+        {
+            'invalid': "This value may contain only letters, numbers, '.' and '-'."
+        }
+    )
+
     email = forms.EmailField(label='Email', required=True)
     first_name = forms.CharField(label='First Name', required=True)
     last_name = forms.CharField(label='Last Name', required=True)


### PR DESCRIPTION
Changes the following functionality:
- `/profile/<ID>` has been moved to `/profile/id/<ID>`
- `/profile/<USERNAME>` is now the standard way to view a profile
- `/profile/` now redirects to `/profile/<YOUR_USERNAME>`, instead of just hiding the username
- usernames for new user registrations are now limited to the characters: `[a-zA-Z0-9.-]` 
